### PR TITLE
Potential fix for code scanning alert no. 59: Server-side request forgery

### DIFF
--- a/backend/src/routes/liability.js
+++ b/backend/src/routes/liability.js
@@ -381,6 +381,13 @@ router.get('/terms-status', authenticateUser, async (req, res) => {
 router.get('/compliance-check/:skillCategory', authenticateUser, async (req, res) => {
   try {
     const { skillCategory } = req.params;
+    // Only allow whitelisted skill categories
+    const ALLOWED_SKILL_CATEGORIES = [
+      'coding', 'cooking', 'painting', 'music', 'design', 'science', 'leadership', 'teaching', 'sports'
+    ];
+    if (!ALLOWED_SKILL_CATEGORIES.includes(skillCategory)) {
+      return res.status(400).json({ error: 'Invalid skill category' });
+    }
     const userId = req.user.uid;
     const db = getFirestore();
 


### PR DESCRIPTION
Potential fix for [https://github.com/GooseyPrime/yoohooguru/security/code-scanning/59](https://github.com/GooseyPrime/yoohooguru/security/code-scanning/59)

To fix this SSRF risk, strictly validate or restrict the possible values for `skillCategory` before making the outgoing fetch request. The recommended approach is to maintain a server-side allow-list of acceptable skill categories. 

Specifically:
- Define a set or array of allowed skill category values (e.g., those supported by the application).
- Before performing the fetch, check that the incoming `skillCategory` from user input is included in this allow-list.
- If the value is not valid, respond with a 400 error and do not continue to make the fetch request.
- Place this check *before* the SSRF-prone code, just after extracting `skillCategory` from `req.params`.
- Additionally, sanitize or encode the variable interpolated into URLs, if you cannot move to a fully allow-list approach (but the allow-list is preferred for this case).
- Only modify code shown, avoiding changes to imports unless strictly required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
