### PR TITLE
Potential fix for code scanning alert no. 51: Missing rate limiting

### DIFF
--- a/backend/src/routes/connectExpressLogin.js
+++ b/backend/src/routes/connectExpressLogin.js
@@ -1,12 +1,20 @@
 const express = require('express');
+const rateLimit = require('express-rate-limit');
 const { stripe } = require('../lib/stripe');
 const { getFirestore } = require('../config/firebase');
 const { authenticateUser } = require('../middleware/auth');
 
 const router = express.Router();
 
+// Define a rate limiter: max 5 requests per minute per IP to this route
+const expressLoginLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 5,
+  message: { ok: false, error: 'Too many attempts, please try again later.' }
+});
+
 // POST /api/connect/express-login
-router.post('/express-login', authenticateUser, async (req, res) => {
+router.post('/express-login', expressLoginLimiter, authenticateUser, async (req, res) => {
   try {
     if (!stripe && process.env.NODE_ENV !== 'test') {
       return res.status(503).json({ 


### PR DESCRIPTION
Potential fix for [https://github.com/GooseyPrime/yoohooguru/security/code-scanning/51](https://github.com/GooseyPrime/yoohooguru/security/code-scanning/51)

To fix this problem, a rate limiting middleware should be introduced and applied to the `/express-login` POST route. The most common and effective approach in Express is to use the well-known `express-rate-limit` package. To avoid impacting the rest of the API, we'll apply the rate limiter specifically to this route. 

**Steps:**
1. Import `express-rate-limit` at the top of the file.
2. Define a rate limiter (e.g., 5 login attempts per minute).
3. Add the rate limiter as middleware in the router for the `/express-login` POST route.

Add the necessary `require` statement, define the limiter before the route registration, and modify the registration to apply the limiter middleware.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
