### PR TITLE
Potential fix for code scanning alert no. 41: Incomplete URL substring sanitization

### DIFF
--- a/scripts/validate-seo-files.js
+++ b/scripts/validate-seo-files.js
@@ -40,10 +40,19 @@ try {
   let nonCanonicalCount = 0;
   
   urlLines.forEach(line => {
-    if (line.includes('https://www.yoohoo.guru/')) {
-      canonicalCount++;
-    } else if (line.includes('https://yoohoo.guru/')) {
-      nonCanonicalCount++;
+    // Extract the URL within the <loc> tag
+    const match = line.match(/<loc>(.*?)<\/loc>/);
+    if (match && match[1]) {
+      try {
+        const locUrl = new URL(match[1]);
+        if (locUrl.hostname === 'www.yoohoo.guru') {
+          canonicalCount++;
+        } else if (locUrl.hostname === 'yoohoo.guru') {
+          nonCanonicalCount++;
+        }
+      } catch (e) {
+        // Invalid URL, skip
+      }
     }
   });
   


### PR DESCRIPTION
Potential fix for [https://github.com/GooseyPrime/yoohooguru/security/code-scanning/41](https://github.com/GooseyPrime/yoohooguru/security/code-scanning/41)

To accurately determine whether a URL is truly for the host `yoohoo.guru` (without the `www` subdomain), we should extract the value from the `<loc>` tag, parse it as a URL, and check its hostname. Instead of substring checks, use a proper URL parser (such as Node.js's built-in `url` or preferably the WHATWG `URL` class) to extract the hostname and compare it directly (e.g., hostname is exactly `yoohoo.guru`). 

To fix, edit the region of code (lines 42-48) that analyzes `<loc>` URLs by:
- Extracting the URL string from inside the `<loc>` tag.
- Parsing the URL using `new URL(...)`.
- Comparing the parsed `hostname` attribute to `yoohoo.guru` or `www.yoohoo.guru` as appropriate.

This approach requires importing no new dependencies, but does require a try/catch for invalid URLs (potentially malformed XML/content).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
