### PR TITLE
Potential fix for code scanning alert no. 39: Incomplete URL substring sanitization

### DIFF
--- a/frontend/src/contexts/AuthContext.js
+++ b/frontend/src/contexts/AuthContext.js
@@ -279,9 +279,27 @@ export function AuthProvider({ children }) {
       let errorMessage = getAuthErrorMessage(error);
       
       // Add specific messaging for CSP and script loading issues
-      if (error.message?.includes('script') || 
-          error.message?.includes('Content Security Policy') ||
-          error.message?.includes('apis.google.com')) {
+      // Helper: extract hostnames from error messages
+      const extractHostnames = (message) => {
+        if (!message) return [];
+        // Simple URL matching regex
+        const regex = /https?:\/\/([^\s/$.?#].[^\s]*)/gi;
+        const matches = message.match(regex) || [];
+        // Return hostnames only
+        return matches.map(urlStr => {
+          try {
+            return (new URL(urlStr)).hostname;
+          } catch { return null; }
+        }).filter(Boolean);
+      };
+      
+      const errorHosts = extractHostnames(error.message);
+      
+      if (
+        error.message?.includes('script') || 
+        error.message?.includes('Content Security Policy') ||
+        errorHosts.includes('apis.google.com')
+      ) {
         errorMessage = 'Google Sign-in is temporarily unavailable due to security restrictions. Please try using email/password authentication or refresh the page.';
       } else if (error.code === 'auth/internal-error') {
         errorMessage = 'Google Sign-in encountered a technical issue. Please try again or use email/password authentication.';


### PR DESCRIPTION
Potential fix for [https://github.com/GooseyPrime/yoohooguru/security/code-scanning/39](https://github.com/GooseyPrime/yoohooguru/security/code-scanning/39)

The best way to fix the issue is to robustly check whether the error message refers to a resource from the canonical `'apis.google.com'` domain, rather than relying on substring matching. Specifically, extract any URLs from the error message, parse each URL, and check if the hostname matches `'apis.google.com'`. This requires importing a URL parsing utility (use the built-in `URL` object for modern JS), extracting URLs using regex from the error message, and checking the host for exact matches. Update the error handling logic at line 284 accordingly.

This change only affects the check in the block around lines 282-286.

Needed:
- Possibly import/use the global URL class.
- Add a helper function (within this file) to safely extract and parse hostnames from URLs found in error messages.
- Update the conditional at line 284 to use this enhanced check.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
