### PR TITLE
Potential fix for code scanning alert no. 65: Clear text transmission of sensitive cookie

### DIFF
--- a/backend/tests/session-lusca-integration.test.js
+++ b/backend/tests/session-lusca-integration.test.js
@@ -132,7 +132,13 @@ describe('Session and Lusca Integration', () => {
       app.use(session({
         secret: 'test_secret',
         resave: false,
-        saveUninitialized: false
+        saveUninitialized: false,
+        cookie: {
+          secure: process.env.NODE_ENV === 'production',
+          httpOnly: true,
+          maxAge: 24 * 60 * 60 * 1000,
+          sameSite: 'lax'
+        }
       }));
       
       app.use(csrf());


### PR DESCRIPTION
Potential fix for [https://github.com/GooseyPrime/yoohooguru/security/code-scanning/65](https://github.com/GooseyPrime/yoohooguru/security/code-scanning/65)

To fix this security issue, the session middleware initialization in the test (line 132) should always explicitly set the `cookie.secure` property, to true when in production and to false otherwise, matching the best practice already described in the file in other tests (e.g., lines 94, 117). This ensures the session cookies are only sent over HTTPS in production, but allows the tests to run in development environments without requiring SSL. 

You should edit the block beginning at line 132, and add in a `cookie` option to the session options — setting `secure` based on the value of `process.env.NODE_ENV`. Add the same recommended settings as in the other session config examples in the file: `httpOnly: true`, `maxAge: 24 * 60 * 60 * 1000`, `sameSite: 'lax'`. No additional imports are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
