### PR TITLE
Potential fix for code scanning alert no. 64: Clear text transmission of sensitive cookie

### DIFF
--- a/backend/tests/session-lusca-integration.test.js
+++ b/backend/tests/session-lusca-integration.test.js
@@ -75,7 +75,13 @@ describe('Session and Lusca Integration', () => {
         app.use(session({
           secret: 'test_secret',
           resave: false,
-          saveUninitialized: false
+          saveUninitialized: false,
+          cookie: {
+            secure: true,
+            httpOnly: true,
+            maxAge: 24 * 60 * 60 * 1000,
+            sameSite: 'lax'
+          }
         }));
       }).not.toThrow(); // Middleware registration doesn't throw, but requests will fail
     });


### PR DESCRIPTION
Potential fix for [https://github.com/GooseyPrime/yoohooguru/security/code-scanning/64](https://github.com/GooseyPrime/yoohooguru/security/code-scanning/64)

The best way to fix the problem is to explicitly specify the `cookie` options in the `express-session` call where the session is initialized in the test. Specifically, set `cookie: { secure: true, httpOnly: true, sameSite: 'lax', maxAge: ... }` (including `secure: true`) in the session configuration object when calling `session()` in the test where `lusca` middleware is initialized before `express-session` (line 75). This will ensure that the session cookie is not transmitted over connections unless they are secured (e.g., HTTPS), thus preventing clear text transmission of session cookies.

You only need to change the session configuration in the `app.use(session({...}))` call on lines 75-79. It's important **not** to remove or change the logical intent of the test: you can copy the cookie configuration used in line 93-97 section as an example. If this test is not supposed to test cookie configuration specifically, setting `secure: true` is still recommended for consistent security practice, especially since this is related to session cookies.

No new imports are required. Just specify the `cookie` property in the session config.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
