### PR TITLE
Potential fix for code scanning alert no. 63: Clear text transmission of sensitive cookie

### DIFF
--- a/backend/tests/session-lusca-integration.test.js
+++ b/backend/tests/session-lusca-integration.test.js
@@ -50,7 +50,8 @@ describe('Session and Lusca Integration', () => {
       app.use(session({
         secret: 'test_secret',
         resave: false,
-        saveUninitialized: false
+        saveUninitialized: false,
+        cookie: { secure: true }
       }));
       
       app.use(csrf());
@@ -75,7 +76,8 @@ describe('Session and Lusca Integration', () => {
         app.use(session({
           secret: 'test_secret',
           resave: false,
-          saveUninitialized: false
+          saveUninitialized: false,
+          cookie: { secure: true }
         }));
       }).not.toThrow(); // Middleware registration doesn't throw, but requests will fail
     });


### PR DESCRIPTION
Potential fix for [https://github.com/GooseyPrime/yoohooguru/security/code-scanning/63](https://github.com/GooseyPrime/yoohooguru/security/code-scanning/63)

To fix the problem, update the session middleware configuration to explicitly set the `secure` flag in the cookie options: `cookie: { secure: true }`. This will ensure that session cookies are only sent over HTTPS connections. Since tests may be running with plain HTTP (not HTTPS), you may need to add a comment that some test runners may need to disable this for local development - but defaulting to secure is recommended. The fix should update the session middleware configuration in all instances within this file, specifically where session is configured on line 50 and line 75. 

You do not need to add any imports; just update the session options object to include the `cookie` key with `secure: true`. Update both test cases to set the secure flag (even in the "incorrect order" test, for consistency).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
