### PR TITLE
Potential fix for code scanning alert no. 54: Exception text reinterpreted as HTML

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -41,7 +41,8 @@
     "node-cron": "^3.0.3",
     "stripe": "^18.5.0",
     "uuid": "^8.3.2",
-    "winston": "^3.18.2"
+    "winston": "^3.18.2",
+    "escape-html": "^1.0.3"
   },
   "devDependencies": {
     "@firebase/rules-unit-testing": "^3.0.0",

--- a/backend/src/routes/stripeWebhooks.js
+++ b/backend/src/routes/stripeWebhooks.js
@@ -2,6 +2,7 @@ const express = require('express');
 const { stripe } = require('../lib/stripe');
 const { getFirestore } = require('../config/firebase');
 const { logger } = require('../utils/logger');
+const escapeHtml = require('escape-html');
 
 const router = express.Router();
 
@@ -82,7 +83,7 @@ router.post('/', async (req, res) => {
     logger.info(`✅ Webhook signature verified - event type: ${event.type}`);
   } catch (err) {
     logger.error('❌ Webhook signature verification failed.', err.message);
-    return res.status(400).send(`Webhook Error: ${err.message}`);
+    return res.status(400).send(`Webhook Error: ${escapeHtml(err.message)}`);
   }
 
   try {


### PR DESCRIPTION
Potential fix for [https://github.com/GooseyPrime/yoohooguru/security/code-scanning/54](https://github.com/GooseyPrime/yoohooguru/security/code-scanning/54)

To mitigate XSS, we must escape/sanitize any content reflected in HTTP responses that may contain untrusted data, especially if sent as text/html or plain text. In this case, we should use contextual encoding for `err.message` before including it in the response. The express response will (by default) set `Content-Type: text/html` for `.send(string)`, so HTML metacharacters in `err.message` could be interpreted as HTML.  
The best/most robust fix:  
- Properly escape HTML metacharacters (`&`, `<`, `>`, `"`, `'`, `/`) in `err.message` before reflecting to the client.
- Use a dedicated library like `he` or `escape-html` for server-side HTML escaping (but only if you can add new dependencies).
- Alternatively, roll out a minimal pure JS escape function if external dependencies aren't allowed.

For this code base, since we can modify imports, the best approach is to use the well-known `escape-html` library (https://www.npmjs.com/package/escape-html), since it's small, maintained, and does exactly what we need.  
Steps:
- Add `const escapeHtml = require('escape-html');` to backend/src/routes/stripeWebhooks.js
- Change line 85 to escape `err.message` using `escapeHtml` before embedding in the string.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
