### PR TITLE
Potential fix for code scanning alert no. 23: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Continuous Integration
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/GooseyPrime/yoohooguru/security/code-scanning/23](https://github.com/GooseyPrime/yoohooguru/security/code-scanning/23)

To address the issue, add a `permissions` block at the top of the workflow that explicitly limits the GITHUB_TOKEN's access. The most restrictive and commonly sufficient permission for CI jobs that check out code, run tests, and upload artifacts is `contents: read`. If jobs need more (which does not seem necessary from the workflow as presented), further scopes like `pull-requests: write` can be added per job.  
**Best way:**  
- Insert a `permissions: contents: read` block just under the workflow `name` and above the `on:` key in `.github/workflows/ci.yml`.  
- This will apply minimal permissions to all jobs unless overridden locally, adhering to least privilege principles.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
