### PR TITLE
Potential fix for code scanning alert no. 96: Server-side request forgery

### DIFF
--- a/apps/main/pages/_apps/sales/blog/[slug].tsx
+++ b/apps/main/pages/_apps/sales/blog/[slug].tsx
@@ -39,6 +39,13 @@ export default function BlogPost() {
 
   useEffect(() => {
     if (!slug) return;
+    // Validate slug: only allow alphanumeric, hyphens, underscores
+    const slugPattern = /^[a-zA-Z0-9_-]+$/;
+    if (typeof slug !== "string" || !slugPattern.test(slug)) {
+      setError("Invalid blog post slug");
+      setLoading(false);
+      return;
+    }
 
     const fetchPost = async () => {
       try {


### PR DESCRIPTION
Potential fix for [https://github.com/GooseyPrime/yoohooguru/security/code-scanning/96](https://github.com/GooseyPrime/yoohooguru/security/code-scanning/96)

To fix the SSRF risk, we should sanitize and validate the `slug` value before using it to construct any outgoing API request URLs. More specifically:
- Validate that the `slug` consists only of allowed characters (e.g., alphanumeric, hyphens, underscores) and does not contain path traversal sequences (`../`), slashes, or other invalid characters.
- Reject or ignore any slug input that does not match the expected pattern.
- This can be achieved by using a regular expression to validate `slug` before invoking the fetch request.
- The validation logic should be placed just before `fetchPost` is invoked, in the useEffect hook.

Required changes:
- Add a regular expression to check that `slug` follows a safe pattern (e.g., `^[a-zA-Z0-9_-]+$`).
- If validation fails, do not proceed with the fetch request and instead set an appropriate error state.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
