### PR TITLE
feat: Add 17 missing skill pages to match all 27 subject domains

### DIFF
--- a/apps/main/pages/skills/auto.tsx
+++ b/apps/main/pages/skills/auto.tsx
@@ -1,0 +1,39 @@
+import CategoryTemplate from '../../components/categories/CategoryTemplate';
+
+export default function AutoSkills() {
+  const skills = [
+    {
+      id: 'auto-repair',
+      title: 'Auto Repair & Diagnostics',
+      description: 'Master automotive repair techniques, diagnostic procedures, and troubleshooting for all vehicle types.'
+    },
+    {
+      id: 'maintenance',
+      title: 'Vehicle Maintenance',
+      description: 'Learn preventive maintenance, oil changes, brake service, and routine vehicle care to keep cars running smoothly.'
+    },
+    {
+      id: 'diagnostics',
+      title: 'Automotive Diagnostics',
+      description: 'Understand modern diagnostic tools, OBD-II systems, and computer-based vehicle troubleshooting.'
+    },
+    {
+      id: 'detailing',
+      title: 'Auto Detailing',
+      description: 'Perfect professional detailing techniques including paint correction, ceramic coating, and interior restoration.'
+    },
+    {
+      id: 'restoration',
+      title: 'Classic Car Restoration',
+      description: 'Restore vintage and classic vehicles to their former glory with expert guidance on bodywork and mechanics.'
+    }
+  ];
+
+  return (
+    <CategoryTemplate
+      categoryName="Auto & Automotive"
+      categoryDescription="Master automotive repair, maintenance, diagnostics, and restoration skills. Learn from expert mechanics and auto professionals."
+      skills={skills}
+    />
+  );
+}

--- a/apps/main/pages/skills/crafts.tsx
+++ b/apps/main/pages/skills/crafts.tsx
@@ -1,0 +1,39 @@
+import CategoryTemplate from '../../components/categories/CategoryTemplate';
+
+export default function CraftsSkills() {
+  const skills = [
+    {
+      id: 'woodworking',
+      title: 'Woodworking',
+      description: 'Learn carpentry, furniture making, and wood crafting techniques from beginner to advanced levels.'
+    },
+    {
+      id: 'knitting',
+      title: 'Knitting & Crocheting',
+      description: 'Master knitting and crochet techniques to create beautiful garments, accessories, and home decor.'
+    },
+    {
+      id: 'sewing',
+      title: 'Sewing & Tailoring',
+      description: 'Develop sewing skills including pattern making, alterations, and creating custom clothing.'
+    },
+    {
+      id: 'pottery',
+      title: 'Pottery & Ceramics',
+      description: 'Create functional and decorative pottery using hand-building and wheel-throwing techniques.'
+    },
+    {
+      id: 'jewelry-making',
+      title: 'Jewelry Making',
+      description: 'Craft unique jewelry pieces using various techniques including metalworking, beading, and wire wrapping.'
+    }
+  ];
+
+  return (
+    <CategoryTemplate
+      categoryName="Crafts & DIY"
+      categoryDescription="Explore hands-on craft skills including woodworking, knitting, sewing, pottery, and jewelry making. Create beautiful handmade projects."
+      skills={skills}
+    />
+  );
+}

--- a/apps/main/pages/skills/data.tsx
+++ b/apps/main/pages/skills/data.tsx
@@ -1,0 +1,39 @@
+import CategoryTemplate from '../../components/categories/CategoryTemplate';
+
+export default function DataSkills() {
+  const skills = [
+    {
+      id: 'data-analysis',
+      title: 'Data Analysis',
+      description: 'Master data analysis techniques using Excel, SQL, and statistical methods to extract meaningful insights.'
+    },
+    {
+      id: 'python',
+      title: 'Python for Data Science',
+      description: 'Learn Python programming for data manipulation, analysis, and visualization using pandas, NumPy, and matplotlib.'
+    },
+    {
+      id: 'sql',
+      title: 'SQL & Database Management',
+      description: 'Write complex SQL queries, design databases, and manage data efficiently in relational database systems.'
+    },
+    {
+      id: 'visualization',
+      title: 'Data Visualization',
+      description: 'Create compelling data visualizations and dashboards using Tableau, Power BI, and Python libraries.'
+    },
+    {
+      id: 'machine-learning',
+      title: 'Machine Learning Basics',
+      description: 'Understand fundamental machine learning concepts and build predictive models with scikit-learn.'
+    }
+  ];
+
+  return (
+    <CategoryTemplate
+      categoryName="Data Science"
+      categoryDescription="Develop data analysis, Python programming, SQL, visualization, and machine learning skills. Transform data into insights."
+      skills={skills}
+    />
+  );
+}

--- a/apps/main/pages/skills/design.tsx
+++ b/apps/main/pages/skills/design.tsx
@@ -1,0 +1,39 @@
+import CategoryTemplate from '../../components/categories/CategoryTemplate';
+
+export default function DesignSkills() {
+  const skills = [
+    {
+      id: 'graphic-design',
+      title: 'Graphic Design',
+      description: 'Master graphic design principles, typography, and visual communication using Adobe Creative Suite.'
+    },
+    {
+      id: 'ui-ux',
+      title: 'UI/UX Design',
+      description: 'Create user-centered digital experiences with modern UI/UX design tools like Figma and Adobe XD.'
+    },
+    {
+      id: 'branding',
+      title: 'Branding & Identity',
+      description: 'Develop cohesive brand identities including logos, color palettes, and brand guidelines.'
+    },
+    {
+      id: 'web-design',
+      title: 'Web Design',
+      description: 'Design beautiful, responsive websites with HTML, CSS, and modern design frameworks.'
+    },
+    {
+      id: 'illustration',
+      title: 'Digital Illustration',
+      description: 'Create stunning digital illustrations for branding, editorial, and commercial projects.'
+    }
+  ];
+
+  return (
+    <CategoryTemplate
+      categoryName="Design"
+      categoryDescription="Learn graphic design, UI/UX, branding, web design, and digital illustration. Create professional visual designs."
+      skills={skills}
+    />
+  );
+}

--- a/apps/main/pages/skills/finance.tsx
+++ b/apps/main/pages/skills/finance.tsx
@@ -1,0 +1,39 @@
+import CategoryTemplate from '../../components/categories/CategoryTemplate';
+
+export default function FinanceSkills() {
+  const skills = [
+    {
+      id: 'personal-finance',
+      title: 'Personal Finance Management',
+      description: 'Master budgeting, saving strategies, debt management, and building wealth for financial independence.'
+    },
+    {
+      id: 'accounting',
+      title: 'Accounting Fundamentals',
+      description: 'Learn accounting principles, financial statements, bookkeeping, and tax preparation basics.'
+    },
+    {
+      id: 'financial-planning',
+      title: 'Financial Planning',
+      description: 'Develop comprehensive financial plans including retirement, insurance, and estate planning.'
+    },
+    {
+      id: 'credit-management',
+      title: 'Credit & Debt Management',
+      description: 'Improve credit scores, manage debt effectively, and understand credit systems.'
+    },
+    {
+      id: 'financial-analysis',
+      title: 'Financial Analysis',
+      description: 'Analyze financial statements, evaluate investments, and make data-driven financial decisions.'
+    }
+  ];
+
+  return (
+    <CategoryTemplate
+      categoryName="Finance"
+      categoryDescription="Master personal finance, accounting, financial planning, and money management skills. Build your financial future."
+      skills={skills}
+    />
+  );
+}

--- a/apps/main/pages/skills/gardening.tsx
+++ b/apps/main/pages/skills/gardening.tsx
@@ -1,0 +1,39 @@
+import CategoryTemplate from '../../components/categories/CategoryTemplate';
+
+export default function GardeningSkills() {
+  const skills = [
+    {
+      id: 'vegetable-gardening',
+      title: 'Vegetable Gardening',
+      description: 'Grow fresh vegetables, herbs, and produce in your backyard or container garden.'
+    },
+    {
+      id: 'landscaping',
+      title: 'Landscaping & Design',
+      description: 'Design and create beautiful outdoor spaces with professional landscaping techniques.'
+    },
+    {
+      id: 'organic-gardening',
+      title: 'Organic Gardening',
+      description: 'Practice sustainable, chemical-free gardening methods for healthier plants and environment.'
+    },
+    {
+      id: 'composting',
+      title: 'Composting & Soil Health',
+      description: 'Create nutrient-rich compost and maintain healthy soil for thriving gardens.'
+    },
+    {
+      id: 'indoor-plants',
+      title: 'Indoor Plant Care',
+      description: 'Successfully grow and maintain houseplants, succulents, and indoor gardens.'
+    }
+  ];
+
+  return (
+    <CategoryTemplate
+      categoryName="Gardening"
+      categoryDescription="Learn vegetable gardening, landscaping, organic methods, and plant care. Create beautiful, productive gardens."
+      skills={skills}
+    />
+  );
+}

--- a/apps/main/pages/skills/history.tsx
+++ b/apps/main/pages/skills/history.tsx
@@ -1,0 +1,39 @@
+import CategoryTemplate from '../../components/categories/CategoryTemplate';
+
+export default function HistorySkills() {
+  const skills = [
+    {
+      id: 'world-history',
+      title: 'World History',
+      description: 'Explore major civilizations, events, and movements that shaped human history across the globe.'
+    },
+    {
+      id: 'american-history',
+      title: 'American History',
+      description: 'Study U.S. history from colonial times through modern era, including key events and figures.'
+    },
+    {
+      id: 'historical-research',
+      title: 'Historical Research Methods',
+      description: 'Learn to conduct historical research, analyze primary sources, and evaluate historical evidence.'
+    },
+    {
+      id: 'genealogy',
+      title: 'Genealogy & Family History',
+      description: 'Trace your family roots, build family trees, and preserve family history for future generations.'
+    },
+    {
+      id: 'ancient-civilizations',
+      title: 'Ancient Civilizations',
+      description: 'Discover ancient cultures including Egypt, Greece, Rome, and Mesopotamia.'
+    }
+  ];
+
+  return (
+    <CategoryTemplate
+      categoryName="History"
+      categoryDescription="Study world history, American history, historical research, and genealogy. Understand the past to inform the present."
+      skills={skills}
+    />
+  );
+}

--- a/apps/main/pages/skills/home.tsx
+++ b/apps/main/pages/skills/home.tsx
@@ -1,0 +1,39 @@
+import CategoryTemplate from '../../components/categories/CategoryTemplate';
+
+export default function HomeSkills() {
+  const skills = [
+    {
+      id: 'home-repair',
+      title: 'Home Repair & Maintenance',
+      description: 'Fix common household issues including plumbing, electrical, and structural repairs.'
+    },
+    {
+      id: 'interior-design',
+      title: 'Interior Design',
+      description: 'Create beautiful, functional living spaces with professional interior design principles.'
+    },
+    {
+      id: 'home-organization',
+      title: 'Home Organization',
+      description: 'Declutter and organize your home with effective storage solutions and organizational systems.'
+    },
+    {
+      id: 'cleaning',
+      title: 'Deep Cleaning Techniques',
+      description: 'Master professional cleaning methods for a spotless, healthy home environment.'
+    },
+    {
+      id: 'renovation',
+      title: 'Home Renovation',
+      description: 'Plan and execute home improvement projects from small updates to major renovations.'
+    }
+  ];
+
+  return (
+    <CategoryTemplate
+      categoryName="Home Improvement"
+      categoryDescription="Learn home repair, interior design, organization, cleaning, and renovation skills. Maintain and improve your living space."
+      skills={skills}
+    />
+  );
+}

--- a/apps/main/pages/skills/investing.tsx
+++ b/apps/main/pages/skills/investing.tsx
@@ -1,0 +1,39 @@
+import CategoryTemplate from '../../components/categories/CategoryTemplate';
+
+export default function InvestingSkills() {
+  const skills = [
+    {
+      id: 'stock-market',
+      title: 'Stock Market Investing',
+      description: 'Learn to invest in stocks, analyze companies, and build a diversified investment portfolio.'
+    },
+    {
+      id: 'real-estate',
+      title: 'Real Estate Investing',
+      description: 'Invest in rental properties, REITs, and real estate for long-term wealth building.'
+    },
+    {
+      id: 'retirement-planning',
+      title: 'Retirement Planning',
+      description: 'Build retirement wealth through 401(k)s, IRAs, and strategic investment planning.'
+    },
+    {
+      id: 'portfolio-management',
+      title: 'Portfolio Management',
+      description: 'Construct and manage investment portfolios with proper asset allocation and risk management.'
+    },
+    {
+      id: 'options-trading',
+      title: 'Options & Trading',
+      description: 'Understand options trading, derivatives, and advanced investment strategies.'
+    }
+  ];
+
+  return (
+    <CategoryTemplate
+      categoryName="Investing"
+      categoryDescription="Master stock market investing, real estate, retirement planning, and portfolio management. Build wealth through smart investing."
+      skills={skills}
+    />
+  );
+}

--- a/apps/main/pages/skills/language.tsx
+++ b/apps/main/pages/skills/language.tsx
@@ -1,0 +1,39 @@
+import CategoryTemplate from '../../components/categories/CategoryTemplate';
+
+export default function LanguageSkills() {
+  const skills = [
+    {
+      id: 'spanish',
+      title: 'Spanish Language',
+      description: 'Learn conversational Spanish, grammar, and cultural fluency for travel or career advancement.'
+    },
+    {
+      id: 'french',
+      title: 'French Language',
+      description: 'Master French pronunciation, vocabulary, and conversation skills from beginner to advanced.'
+    },
+    {
+      id: 'mandarin',
+      title: 'Mandarin Chinese',
+      description: 'Study Mandarin characters, tones, and conversational skills for business or personal growth.'
+    },
+    {
+      id: 'esl',
+      title: 'English as Second Language',
+      description: 'Improve English fluency, grammar, and communication skills for non-native speakers.'
+    },
+    {
+      id: 'language-learning',
+      title: 'Language Learning Methods',
+      description: 'Discover effective techniques and strategies for learning any foreign language efficiently.'
+    }
+  ];
+
+  return (
+    <CategoryTemplate
+      categoryName="Language Learning"
+      categoryDescription="Learn Spanish, French, Mandarin, English, and effective language learning techniques. Communicate across cultures."
+      skills={skills}
+    />
+  );
+}

--- a/apps/main/pages/skills/marketing.tsx
+++ b/apps/main/pages/skills/marketing.tsx
@@ -1,0 +1,39 @@
+import CategoryTemplate from '../../components/categories/CategoryTemplate';
+
+export default function MarketingSkills() {
+  const skills = [
+    {
+      id: 'digital-marketing',
+      title: 'Digital Marketing',
+      description: 'Master online marketing strategies including SEO, social media, email, and content marketing.'
+    },
+    {
+      id: 'social-media',
+      title: 'Social Media Marketing',
+      description: 'Build brand presence and engage audiences across Facebook, Instagram, LinkedIn, and TikTok.'
+    },
+    {
+      id: 'content-marketing',
+      title: 'Content Marketing',
+      description: 'Create compelling content that attracts, engages, and converts your target audience.'
+    },
+    {
+      id: 'seo',
+      title: 'SEO & Search Marketing',
+      description: 'Optimize websites for search engines and drive organic traffic with proven SEO techniques.'
+    },
+    {
+      id: 'email-marketing',
+      title: 'Email Marketing',
+      description: 'Build email campaigns, grow subscriber lists, and maximize email marketing ROI.'
+    }
+  ];
+
+  return (
+    <CategoryTemplate
+      categoryName="Marketing"
+      categoryDescription="Learn digital marketing, social media, content creation, SEO, and email marketing. Grow your brand and reach."
+      skills={skills}
+    />
+  );
+}

--- a/apps/main/pages/skills/math.tsx
+++ b/apps/main/pages/skills/math.tsx
@@ -1,0 +1,39 @@
+import CategoryTemplate from '../../components/categories/CategoryTemplate';
+
+export default function MathSkills() {
+  const skills = [
+    {
+      id: 'algebra',
+      title: 'Algebra',
+      description: 'Master algebraic concepts including equations, functions, and problem-solving techniques.'
+    },
+    {
+      id: 'calculus',
+      title: 'Calculus',
+      description: 'Learn differential and integral calculus for advanced mathematics and real-world applications.'
+    },
+    {
+      id: 'statistics',
+      title: 'Statistics & Probability',
+      description: 'Understand statistical analysis, probability theory, and data interpretation methods.'
+    },
+    {
+      id: 'geometry',
+      title: 'Geometry & Trigonometry',
+      description: 'Study geometric shapes, spatial reasoning, and trigonometric functions and identities.'
+    },
+    {
+      id: 'applied-math',
+      title: 'Applied Mathematics',
+      description: 'Apply mathematical concepts to solve real-world problems in science, engineering, and finance.'
+    }
+  ];
+
+  return (
+    <CategoryTemplate
+      categoryName="Mathematics"
+      categoryDescription="Master algebra, calculus, statistics, geometry, and applied mathematics. Build strong mathematical foundations."
+      skills={skills}
+    />
+  );
+}

--- a/apps/main/pages/skills/mechanical.tsx
+++ b/apps/main/pages/skills/mechanical.tsx
@@ -1,0 +1,39 @@
+import CategoryTemplate from '../../components/categories/CategoryTemplate';
+
+export default function MechanicalSkills() {
+  const skills = [
+    {
+      id: 'mechanical-engineering',
+      title: 'Mechanical Engineering',
+      description: 'Master mechanical engineering principles, mechanics, thermodynamics, and machine design.'
+    },
+    {
+      id: 'cad-design',
+      title: 'CAD Design',
+      description: 'Create professional technical drawings and 3D models using AutoCAD, SolidWorks, and Fusion 360.'
+    },
+    {
+      id: 'manufacturing',
+      title: 'Manufacturing Processes',
+      description: 'Understand manufacturing methods including CNC machining, welding, and quality control.'
+    },
+    {
+      id: 'robotics',
+      title: 'Robotics & Automation',
+      description: 'Build and program robots, understand automation systems, and mechanical control systems.'
+    },
+    {
+      id: 'thermodynamics',
+      title: 'Thermodynamics & HVAC',
+      description: 'Study heat transfer, energy systems, and HVAC design for mechanical applications.'
+    }
+  ];
+
+  return (
+    <CategoryTemplate
+      categoryName="Mechanical Engineering"
+      categoryDescription="Learn mechanical engineering, CAD design, manufacturing, robotics, and thermodynamics. Master mechanical systems."
+      skills={skills}
+    />
+  );
+}

--- a/apps/main/pages/skills/sales.tsx
+++ b/apps/main/pages/skills/sales.tsx
@@ -1,0 +1,39 @@
+import CategoryTemplate from '../../components/categories/CategoryTemplate';
+
+export default function SalesSkills() {
+  const skills = [
+    {
+      id: 'sales-techniques',
+      title: 'Sales Techniques',
+      description: 'Master proven sales methods, closing strategies, and persuasion techniques for any industry.'
+    },
+    {
+      id: 'negotiation',
+      title: 'Negotiation Skills',
+      description: 'Develop powerful negotiation tactics to close deals and create win-win outcomes.'
+    },
+    {
+      id: 'b2b-sales',
+      title: 'B2B Sales',
+      description: 'Excel in business-to-business sales including account management and enterprise selling.'
+    },
+    {
+      id: 'customer-relations',
+      title: 'Customer Relationship Management',
+      description: 'Build lasting customer relationships, manage CRM systems, and maximize customer lifetime value.'
+    },
+    {
+      id: 'cold-calling',
+      title: 'Cold Calling & Prospecting',
+      description: 'Generate leads and book appointments through effective cold calling and prospecting strategies.'
+    }
+  ];
+
+  return (
+    <CategoryTemplate
+      categoryName="Sales"
+      categoryDescription="Master sales techniques, negotiation, B2B sales, customer relations, and prospecting. Close more deals and grow revenue."
+      skills={skills}
+    />
+  );
+}

--- a/apps/main/pages/skills/science.tsx
+++ b/apps/main/pages/skills/science.tsx
@@ -1,0 +1,39 @@
+import CategoryTemplate from '../../components/categories/CategoryTemplate';
+
+export default function ScienceSkills() {
+  const skills = [
+    {
+      id: 'biology',
+      title: 'Biology & Life Sciences',
+      description: 'Study living organisms, cellular biology, genetics, and ecosystem dynamics.'
+    },
+    {
+      id: 'chemistry',
+      title: 'Chemistry',
+      description: 'Understand chemical reactions, molecular structures, and laboratory techniques.'
+    },
+    {
+      id: 'physics',
+      title: 'Physics',
+      description: 'Explore mechanics, electromagnetism, thermodynamics, and quantum physics principles.'
+    },
+    {
+      id: 'environmental-science',
+      title: 'Environmental Science',
+      description: 'Learn about ecosystems, climate change, sustainability, and environmental conservation.'
+    },
+    {
+      id: 'lab-techniques',
+      title: 'Laboratory Techniques',
+      description: 'Master scientific methodology, experimental design, and laboratory safety protocols.'
+    }
+  ];
+
+  return (
+    <CategoryTemplate
+      categoryName="Science"
+      categoryDescription="Explore biology, chemistry, physics, environmental science, and laboratory techniques. Understand the natural world."
+      skills={skills}
+    />
+  );
+}

--- a/apps/main/pages/skills/sports.tsx
+++ b/apps/main/pages/skills/sports.tsx
@@ -1,0 +1,39 @@
+import CategoryTemplate from '../../components/categories/CategoryTemplate';
+
+export default function SportsSkills() {
+  const skills = [
+    {
+      id: 'basketball',
+      title: 'Basketball',
+      description: 'Improve basketball fundamentals, shooting technique, ball handling, and game strategy.'
+    },
+    {
+      id: 'soccer',
+      title: 'Soccer',
+      description: 'Master soccer skills including dribbling, passing, shooting, and tactical positioning.'
+    },
+    {
+      id: 'tennis',
+      title: 'Tennis',
+      description: 'Develop tennis technique, footwork, serve, and competitive match play strategies.'
+    },
+    {
+      id: 'golf',
+      title: 'Golf',
+      description: 'Perfect your golf swing, putting, course management, and mental game for lower scores.'
+    },
+    {
+      id: 'coaching',
+      title: 'Sports Coaching',
+      description: 'Learn coaching methods, team management, player development, and game strategy.'
+    }
+  ];
+
+  return (
+    <CategoryTemplate
+      categoryName="Sports & Athletics"
+      categoryDescription="Improve skills in basketball, soccer, tennis, golf, and sports coaching. Elevate your athletic performance."
+      skills={skills}
+    />
+  );
+}

--- a/apps/main/pages/skills/writing.tsx
+++ b/apps/main/pages/skills/writing.tsx
@@ -1,0 +1,39 @@
+import CategoryTemplate from '../../components/categories/CategoryTemplate';
+
+export default function WritingSkills() {
+  const skills = [
+    {
+      id: 'creative-writing',
+      title: 'Creative Writing',
+      description: 'Develop storytelling skills, character development, and narrative techniques for fiction writing.'
+    },
+    {
+      id: 'copywriting',
+      title: 'Copywriting',
+      description: 'Write persuasive marketing copy, sales pages, and advertisements that convert.'
+    },
+    {
+      id: 'technical-writing',
+      title: 'Technical Writing',
+      description: 'Create clear documentation, manuals, and technical content for specialized audiences.'
+    },
+    {
+      id: 'blogging',
+      title: 'Blogging & Content Creation',
+      description: 'Build successful blogs, write engaging content, and grow your online audience.'
+    },
+    {
+      id: 'editing',
+      title: 'Editing & Proofreading',
+      description: 'Master editing techniques, grammar, style, and polish written content to perfection.'
+    }
+  ];
+
+  return (
+    <CategoryTemplate
+      categoryName="Writing"
+      categoryDescription="Master creative writing, copywriting, technical writing, blogging, and editing. Craft compelling written content."
+      skills={skills}
+    />
+  );
+}


### PR DESCRIPTION
Created skill pages for:
- auto, crafts, data, design, finance
- gardening, history, home, investing
- language, marketing, math, mechanical
- sales, science, sports, writing

Each page follows the CategoryTemplate pattern with 4-5 relevant skills per category. This brings the total skill pages to 27, matching the number of subject domain apps.

Fixes: Build showing only 10 skill pages instead of 27