### PR TITLE
fix: Improve OAuth error handling and user feedback

### DIFF
--- a/apps/main/pages/auth/error.tsx
+++ b/apps/main/pages/auth/error.tsx
@@ -104,6 +104,18 @@ const SecondaryButton = styled(Button)`
 `
 
 const errorMessages: Record<string, { title: string; description: string }> = {
+  OAuthCallback: {
+    title: 'OAuth Callback Error',
+    description: 'There was an issue completing the Google sign-in process. This may be due to a configuration issue or an interrupted authentication flow. Please try signing in again, or contact support if the problem persists.',
+  },
+  OAuthSignin: {
+    title: 'OAuth Sign-In Error',
+    description: 'An error occurred while attempting to sign in with Google. Please try again or use a different authentication method.',
+  },
+  OAuthCreateAccount: {
+    title: 'Account Creation Error',
+    description: 'We could not create your account using Google authentication. Please try signing up with email and password instead.',
+  },
   Configuration: {
     title: 'Configuration Error',
     description: 'There was an issue with the authentication configuration. Please try again later or contact support if the problem persists.',

--- a/apps/main/pages/login.tsx
+++ b/apps/main/pages/login.tsx
@@ -1,9 +1,19 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { signIn } from 'next-auth/react';
 import Navigation from '../components/ui/Navigation';
+
+const oauthErrorMessages: Record<string, string> = {
+  OAuthCallback: 'Google authentication failed. This may be due to a configuration issue. Please try again or contact support if the problem persists.',
+  OAuthSignin: 'Error occurred while signing in with Google. Please try again.',
+  OAuthCreateAccount: 'Could not create account with Google. Please try a different method.',
+  Configuration: 'There is a problem with the server configuration. Please contact support.',
+  AccessDenied: 'Access was denied. You may not have permission to sign in.',
+  Verification: 'The verification token has expired or has already been used.',
+  Default: 'An authentication error occurred. Please try again.',
+};
 
 export default function Login() {
   const router = useRouter();
@@ -12,6 +22,15 @@ export default function Login() {
   const [rememberMe, setRememberMe] = useState(false);
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+
+  // Detect OAuth errors from URL query parameters
+  useEffect(() => {
+    const errorParam = router.query.error as string;
+    if (errorParam) {
+      const errorMessage = oauthErrorMessages[errorParam] || oauthErrorMessages.Default;
+      setError(errorMessage);
+    }
+  }, [router.query.error]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/apps/main/pages/signup.tsx
+++ b/apps/main/pages/signup.tsx
@@ -1,9 +1,19 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { signIn } from 'next-auth/react';
 import Navigation from '../components/ui/Navigation';
+
+const oauthErrorMessages: Record<string, string> = {
+  OAuthCallback: 'Google authentication failed. This may be due to a configuration issue. Please try again or contact support if the problem persists.',
+  OAuthSignin: 'Error occurred while signing in with Google. Please try again.',
+  OAuthCreateAccount: 'Could not create account with Google. Please try a different method.',
+  Configuration: 'There is a problem with the server configuration. Please contact support.',
+  AccessDenied: 'Access was denied. You may not have permission to sign in.',
+  Verification: 'The verification token has expired or has already been used.',
+  Default: 'An authentication error occurred. Please try again.',
+};
 
 export default function Signup() {
   const router = useRouter();
@@ -20,6 +30,15 @@ export default function Signup() {
 
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
+
+  // Detect OAuth errors from URL query parameters
+  useEffect(() => {
+    const errorParam = router.query.error as string;
+    if (errorParam) {
+      const errorMessage = oauthErrorMessages[errorParam] || oauthErrorMessages.Default;
+      setError(errorMessage);
+    }
+  }, [router.query.error]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();


### PR DESCRIPTION
When Google OAuth authentication fails, users were stuck on the login page with no error message displayed. This fix improves error visibility and user experience.

Changes:
- login.tsx: Detect OAuth error from URL query params and display message
- signup.tsx: Detect OAuth error from URL query params and display message
- auth/error.tsx: Add OAuthCallback and OAuth-specific error messages

The OAuthCallback error typically indicates:
1. Callback URL mismatch in Google OAuth Console
2. Missing/incorrect NEXTAUTH_URL environment variable
3. Missing/incorrect NEXTAUTH_SECRET environment variable
4. Missing AUTH_COOKIE_DOMAIN for cross-subdomain auth

Users will now see clear error messages explaining what went wrong and next steps to take.