### PR TITLE
feat: Implement NextAuth CredentialsProvider for email/password authe…

### DIFF
--- a/apps/main/pages/login.tsx
+++ b/apps/main/pages/login.tsx
@@ -38,25 +38,22 @@ export default function Login() {
     setIsLoading(true);
 
     try {
-      // Call backend API for email/password authentication
-      const response = await fetch('/api/backend/auth/login', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ email, password }),
+      // Use NextAuth credentials provider for email/password authentication
+      const result = await signIn('credentials', {
+        email,
+        password,
+        redirect: false,
       });
 
-      if (response.ok) {
-        // After successful backend authentication, redirect to dashboard
+      if (result?.error) {
+        setError('Invalid email or password');
+        setIsLoading(false);
+      } else if (result?.ok) {
+        // Successful authentication - redirect to dashboard
         router.push('/dashboard');
-      } else {
-        const errorData = await response.json();
-        setError(errorData.error?.message || 'Invalid email or password');
       }
     } catch {
       setError('An error occurred during login. Please try again.');
-    } finally {
       setIsLoading(false);
     }
   };

--- a/apps/main/pages/signup.tsx
+++ b/apps/main/pages/signup.tsx
@@ -63,7 +63,7 @@ export default function Signup() {
     setIsLoading(true);
 
     try {
-      // Call backend API for registration
+      // Call backend API for registration (creates Firebase user and Firestore profile)
       const response = await fetch('/api/backend/auth/register', {
         method: 'POST',
         headers: {
@@ -80,8 +80,19 @@ export default function Signup() {
       });
 
       if (response.ok) {
-        // Redirect to dashboard after successful registration
-        router.push('/dashboard');
+        // After successful registration, sign in with NextAuth to create session
+        const signInResult = await signIn('credentials', {
+          email: formData.email,
+          password: formData.password,
+          redirect: false,
+        });
+
+        if (signInResult?.ok) {
+          // Successfully registered and signed in - redirect to dashboard
+          router.push('/dashboard');
+        } else {
+          setError('Registration succeeded but automatic login failed. Please try logging in manually.');
+        }
       } else {
         const errorData = await response.json();
         setError(errorData.error?.message || 'Registration failed. Please try again.');


### PR DESCRIPTION
…ntication

This properly implements email/password authentication using NextAuth, which is the designated authentication provider for the entire site. This ensures consistent session management with cross-subdomain persistence.

Changes:

1. apps/main/pages/api/auth/[...nextauth].ts
   - Added CredentialsProvider to NextAuth configuration
   - Provider verifies credentials using Firebase Auth REST API
   - Fetches user profile from backend to populate session
   - Returns user object for NextAuth JWT session

2. apps/main/pages/login.tsx
   - Changed from calling backend /api/auth/login endpoint directly
   - Now uses signIn('credentials') for NextAuth session creation
   - Maintains same error handling and user experience

3. apps/main/pages/signup.tsx
   - Registration still calls backend to create Firebase user + Firestore profile
   - After successful registration, automatically signs in with NextAuth
   - Creates NextAuth session so user is actually logged in after signup

Architecture:
- Google OAuth: signIn('google') → NextAuth session with cross-subdomain cookies
- Email/Password: signIn('credentials') → NextAuth session with cross-subdomain cookies
- Both flows create the same session type with domain=.yoohoo.guru
- Backend validates NextAuth JWT tokens (already implemented in middleware)

This fixes the broken authentication flow where users were registering but not being logged in, and login attempts were calling non-existent endpoints.

CSRF exemption for /api/auth/register already exists (PR #509), so registration calls work without CSRF tokens (correct for public endpoints).